### PR TITLE
38-implement-exception-handling-for-frontend-react

### DIFF
--- a/templates/STRMFrontendTemplates/react/components/shared/NotFoundErrorBoundary.tsx
+++ b/templates/STRMFrontendTemplates/react/components/shared/NotFoundErrorBoundary.tsx
@@ -1,0 +1,51 @@
+/**
+ * @author SaiForceOne
+ * @description This represents an error element for 404-type errors. You are expected
+ * to customize this to your own specifications or to fit with your app design. The name
+ * of this component does not need to be changed.
+ */
+
+// Core imports
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+
+const PAGE_TITLE = 'ST🌀RM';
+
+/**
+ * @function NotFoundErrorBoundary
+ * @description Defines an error component to be shown for 404 type errors in
+ * our React application. You only need to customize the markup returned by this
+ * component
+ * @constructor
+ * @returns {React.ReactElement}
+ */
+function NotFoundErrorBoundary(): React.ReactElement {
+  // 📝 Developer Note: You generally only need to change what is returned from
+  // this function below
+  return (
+    <div
+      className='w-full min-h-screen text-white flex flex-col bg-gradient-to-b from-strm-bg-dark to-strm-bg-lighter p-2'>
+      <div className='flex flex-col gap-y-4'>
+        <h1 className='font-heading text-4xl text-center'>{PAGE_TITLE} Stack</h1>
+        <p className='text-lg text-center'>
+          The 🌀 blew away the component you are looking for 🙃
+        </p>
+        <img src='/static/dist/images/404-not-found.jpg' alt='404 not found' />
+        <h2 className='text-2xl text-center font-heading'>What to do next?</h2>
+        <div className='flex flex-col items-center gap-y-2'>
+
+          <Link className='text-center w-fit hover:underline' to='/'>Navigate to Home</Link>
+          <p className='text-center'>You should probably update this component to better fit your app's overall theme.
+            The
+            component can be
+            edited: <span
+              className='px-1 py-0.5 italic rounded-sm text-white bg-strm-bg-dark'>strm_fe_react/src/components/shared/NotFoundErrorBoundary.tsx</span>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default NotFoundErrorBoundary;

--- a/templates/STRMFrontendTemplates/react/routes/index.tsx
+++ b/templates/STRMFrontendTemplates/react/routes/index.tsx
@@ -10,6 +10,7 @@ import { RouteObject } from 'react-router-dom';
 // S.T.🌀.R.M Stack Imports
 import { STRMApp } from '🌀/@types/strm_fe';
 import _strmResources from '../../../strm_modules/strm_modules.json';
+import NotFoundErrorBoundary from '🌀/components/shared/NotFoundErrorBoundary';
 
 /**
  * @async
@@ -21,7 +22,6 @@ export function buildRoutes(): Array<RouteObject> {
   const strmModules = _strmResources as STRMApp.STRMModulesFile;
   const output: Array<RouteObject> = [];
 
-  // todo: can this be flattened?
   for (const moduleKey of Object.keys(strmModules.modules)) {
     const module = strmModules.modules[moduleKey] as STRMApp.STRMModule;
     for (const page of module.pages) {
@@ -33,6 +33,7 @@ export function buildRoutes(): Array<RouteObject> {
         element: <Element />,
         id: page.componentName,
         path: page.path,
+        errorElement: <NotFoundErrorBoundary />,
       };
 
       output.push(_route);


### PR DESCRIPTION
This PR closes #38 
- implement an error boundary component that will serve as an error Element on routes