### PR TITLE
41-implement-error-handling-for-frontend-option-vuejs

### DIFF
--- a/templates/STRMFrontendTemplates/vue/components/shared/NotFound.vue
+++ b/templates/STRMFrontendTemplates/vue/components/shared/NotFound.vue
@@ -1,0 +1,59 @@
+<script lang="ts">
+/**
+ * @author SaiForceOne/ST🌀RM Stack CLI
+ * @description Defines the equivalent of a 404-not found page for routes that
+ * are not found. This only has a minimal design and should be updated as needed
+ * to fit your current design.
+ */
+
+// Core imports
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  computed: {
+    /**
+     * @description To ensure that the 404 image is loaded properly, we use attempt
+     * to resolve the image based on the filesystem path. Refer to the link for
+     * more info: 🔗 https://vitejs.dev/guide/assets
+     * @constructor
+     */
+    RESOLVED_404_IMG() {
+      return new URL(
+        '../../../../static/dist/images/404-not-found.jpeg',
+        import.meta.url
+      ).href;
+    },
+    PAGE_TITLE() {
+      return 'ST🌀RM';
+    },
+  },
+  name: 'NotFound',
+});
+</script>
+
+<template>
+  <div
+    class="w-full min-h-screen text-white flex flex-col bg-gradient-to-b from-strm-bg-dark to-strm-bg-lighter p-2"
+  >
+    <div class="flex flex-col gap-y-4">
+      <h1 class="font-heading text-4xl text-center">{{ PAGE_TITLE }} Stack</h1>
+      <p class="text-lg text-center">
+        The 🌀 blew away the component you are looking for 🙃
+      </p>
+      <img :src="RESOLVED_404_IMG" alt="404 not found" />
+      <h2 class="text-2xl text-center font-heading">What to do next?</h2>
+      <div class="flex flex-col items-center gap-y-2">
+        <router-link class="text-center w-fit hover:underline" to="/">
+          Navigate to Home
+        </router-link>
+        <p class="text-center">
+          You should probably update this component to better fit your app's
+          overall theme. The component can be edited:
+          <span class="px-1 py-0.5 italic rounded-sm text-white bg-strm-bg-dark"
+            >strm_fe_vue/src/components/shared/NotFound.vue</span
+          >
+        </p>
+      </div>
+    </div>
+  </div>
+</template>

--- a/templates/STRMFrontendTemplates/vue/main.ts
+++ b/templates/STRMFrontendTemplates/vue/main.ts
@@ -6,6 +6,7 @@
 // Core & third-party imports
 import { createApp } from 'vue';
 import { createRouter, createWebHashHistory } from 'vue-router';
+import type { RouteRecordRaw } from 'vue-router';
 import { OhVueIcon, addIcons } from 'oh-vue-icons';
 import {
   BiStarFill,
@@ -20,24 +21,47 @@ import {
 // ST🌀RM Stack Imports
 import { buildRoutes } from '🌀/routes';
 import App from './App.vue';
+// Import the 404 - Not Found component
+import NotFound from '🌀/components/shared/NotFound.vue';
+
+/**
+ * @description Defines the application routes as an array
+ */
+const routes: Array<RouteRecordRaw> = [
+  /**
+   * 📝 Developer Note:
+   * Unpack the auto-generated routes. These routes are generated from ST🌀RM Modules
+   */
+  ...buildRoutes(),
+  /**
+   * 📝 Developer Note:
+   * Add custom / catch all routes below
+   */
+  {
+    path: '/:pathMatch(.*)*',
+    name: 'NotFound',
+    component: NotFound,
+  },
+];
 
 /**
  * Main application router for the frontend of this ST🌀RM Stack application
  *
- * Developer Note:
- * you can make changes here as needed. Routes can be manually added to routes/_routes.json if necessary.
- * Please note that when the CLI generates a new route, the contents of the _routes.json file will be updated
+ * 📝 Developer Note:
+ * you can make changes here as needed. Routes can be manually added to storm_modules/storm_modules.json if necessary.
+ * Refer to the ST🌀RM Stack CLI manual for more details on how to manually add frontend routes.
+ * Please note that when the CLI generates a ST🌀RM module, the contents of the storm_modules.json file will be updated
  * accordingly.
  */
 const router = createRouter({
   history: createWebHashHistory(),
-  routes: buildRoutes(),
+  routes,
 });
 
 /**
  * Add Icons for the Welcome page
  *
- * Developer Note:
+ * 📝 Developer Note:
  * You can continue to use oh-vue-icons or completely remove it from your project and
  * provide your own icons.
  * */


### PR DESCRIPTION
This PR closes #41 
- implement 404 error page component
- update route generator to include 404 error handler/catch all route and link 404 error page component

![image](https://github.com/saiforceone/strm-cli/assets/97003335/474e3174-d119-4ae1-af68-86cd2d594c37)
